### PR TITLE
Allow Cache\File to use an absolute path for the temp directory

### DIFF
--- a/src/Trustpilot/Cache/File.php
+++ b/src/Trustpilot/Cache/File.php
@@ -63,10 +63,14 @@ class File implements CacheInterface
     public function __construct($cacheTimeLimit = self::CACHE_TIME_LIMIT, $temporaryFolderName = self::TEMPORARY_FOLDER_NAME)
     {
         $this->cacheTimeLimit = $cacheTimeLimit;
-        $this->temporaryPath = sprintf(
-            '%s%s%s',
-            rtrim(sys_get_temp_dir(), DIRECTORY_SEPARATOR), DIRECTORY_SEPARATOR, $temporaryFolderName
-        );
+        if (substr($temporaryFolderName, 0, 1) == '/') {
+            $this->temporaryPath = $temporaryFolderName;
+        } else {
+            $this->temporaryPath = sprintf(
+                '%s%s%s',
+                rtrim(sys_get_temp_dir(), DIRECTORY_SEPARATOR), DIRECTORY_SEPARATOR, $temporaryFolderName
+            );
+        }
 
         $fs = new Filesystem();
         if (!$fs->exists($this->temporaryPath)) {


### PR DESCRIPTION
Existing implementation uses the system-wide temp directory, but it is sometimes useful to inject an absolute path into the constructor, e.g. if the location has been computed elsewhere, or for an application with a self-contained cache directory (most Symfony 2 apps for example).

I needed this for example while working on my current Symfony 2 application - other cache files are in /var/www/myApplication/app/cache/(dev|prod|test), so I didn't really want the TrustPilot one to be in /tmp.

Hope it's ok. :)